### PR TITLE
Update stored sections path for project time tracker

### DIFF
--- a/addons/project-time-tracker/project-time-tracker.gd
+++ b/addons/project-time-tracker/project-time-tracker.gd
@@ -2,7 +2,7 @@
 extends EditorPlugin
 
 
-const STORED_SECTIONS_PATH : String = "res://project_time_traker.json"
+const STORED_SECTIONS_PATH : String = "res://config/project_time_traker.json"
 
 var _dock_instance : Control
 var _timer_afk : Timer


### PR DESCRIPTION
changed the location of json file from root directory to res://config   for reducing visual clutter. Realistically something like that is somewhere people usually put it for big projects & seemed like a good practice. 